### PR TITLE
Allow `conf set` to use curly quotes

### DIFF
--- a/src/conf.coffee
+++ b/src/conf.coffee
@@ -59,10 +59,10 @@ module.exports = (robot) ->
     else
       res.send "#{id} is unset"
 
-  robot.respond ///conf\s+set\s+"(#{SPACED_IDENTIFIER})"\s+(["“].*["”])///, (res) ->
+  robot.respond ///conf\s+set\s+"(#{SPACED_IDENTIFIER})"\s+(["\u201C].*["\u201D])///, (res) ->
     respondSet res, unspaced(res.match[1]), res.match[2].replace(/[\u201C\u201D]/g, '"')
 
-  robot.respond ///conf\s+set\s+(#{IDENTIFIER})\s+(["“].*["”])///, (res) ->
+  robot.respond ///conf\s+set\s+(#{IDENTIFIER})\s+(["\u201C].*["\u201D])///, (res) ->
     respondSet res, res.match[1], res.match[2].replace(/[\u201C\u201D]/g, '"')
 
   respondSet = (res, id, value) ->

--- a/src/conf.coffee
+++ b/src/conf.coffee
@@ -59,11 +59,11 @@ module.exports = (robot) ->
     else
       res.send "#{id} is unset"
 
-  robot.respond ///conf\s+set\s+"(#{SPACED_IDENTIFIER})"\s+(".*")///, (res) ->
-    respondSet res, unspaced(res.match[1]), res.match[2]
+  robot.respond ///conf\s+set\s+"(#{SPACED_IDENTIFIER})"\s+(["“].*["”])///, (res) ->
+    respondSet res, unspaced(res.match[1]), res.match[2].replace(/[\u201C\u201D]/g, '"')
 
-  robot.respond ///conf\s+set\s+(#{IDENTIFIER})\s+(".*")///, (res) ->
-    respondSet res, res.match[1], res.match[2]
+  robot.respond ///conf\s+set\s+(#{IDENTIFIER})\s+(["“].*["”])///, (res) ->
+    respondSet res, res.match[1], res.match[2].replace(/[\u201C\u201D]/g, '"')
 
   respondSet = (res, id, value) ->
     try


### PR DESCRIPTION
When trying to use Hubot with Slack, it kept trying to replace straight quotes with curly quotes, so I patched things to make Hubot accept the curly quotes—changed the regexes to accept curly quotes and then replace them with straight quotes before processing further.